### PR TITLE
Typo fix: rem instead of em on .f3-ns

### DIFF
--- a/tachyons-type-scale.css
+++ b/tachyons-type-scale.css
@@ -16,7 +16,7 @@
  .mega-ns { font-size: 4rem; }
  .f1-ns {   font-size: 2rem; }
  .f2-ns {   font-size: 1.5rem; }
- .f3-ns {   font-size: 1.25em; }
+ .f3-ns {   font-size: 1.25rem; }
  .f4-ns {   font-size: 1rem; }
  .f5-ns {   font-size: .85rem; }
 }


### PR DESCRIPTION
Just noticed that on `.f3-ns` Tachyons uses `em`s instead of `rem`s. I'm assuming this is just a typo, so this PR fixes it,
